### PR TITLE
Add the 2 new dark themes

### DIFF
--- a/pub/data/themes.json
+++ b/pub/data/themes.json
@@ -24,6 +24,18 @@
     "colour": "f6cece"
   },
   {
+    "name": "Dark",
+    "shortName": "csh-dark-material-bootstrap",
+    "cdn": "https://assets.csh.rit.edu/csh-dark-material-bootstrap/4.3.1/dist/csh-dark-material-bootstrap.min.css",
+    "colour": "b0197e"
+  },
+  {
+    "name": "Classic",
+    "shortName": "csh-classic-material-bootstrap",
+    "cdn": "https://assets.csh.rit.edu/csh-classic-material-bootstrap/4.3.1/dist/csh-classic-material-bootstrap.min.css",
+    "colour": "279901"
+  },
+  {
     "name": "",
     "shortName": "break",
     "cdn": "",


### PR DESCRIPTION
Adds the new `csh-dark-material-bootstrap` and `csh-classic-material-bootstrap` themes.